### PR TITLE
Fix: decouple rules for jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ This is an ESLint shareable config that is intended for use within EarlyCross.
 
 Currently, this package contains three presets.
 
-| Presets                     | Details                                                        |
-| --------------------------- | -------------------------------------------------------------- |
-| earlycross/javascript       | For project written entirely in JavaScript                     |
-| earlycross/typescript       | For project written in TypeScript (including JavaScript)       |
-| earlycross/typescript-react | For react project written in TypeScript (including JavaScript) |
+| Presets                       | Details                                                        |
+| ----------------------------- | -------------------------------------------------------------- |
+| `earlycross/javascript`       | For project written entirely in JavaScript                     |
+| `earlycross/typescript`       | For project written in TypeScript (including JavaScript)       |
+| `earlycross/typescript-react` | For react project written in TypeScript (including JavaScript) |
+
+Plus, `earlycross/jest` preset is provided for projects which use Jest. This preset is intended to be used along with presets above.
 
 ## Dependent configs or plugins
 
@@ -16,7 +18,6 @@ Currently, this package contains three presets.
 
 - eslint-config-prettier
 - eslint-plugin-import
-- eslint-plugin-jest
 - eslint-plugin-jsdoc
 
 ### TypeScript
@@ -34,6 +35,10 @@ In addition to TypeScript
 - eslint-plugin-react
 - eslint-plugin-react-hooks
 - eslint-plugin-testing-library
+
+### Jest
+
+- eslint-plugin-jest
 
 ## Install
 
@@ -99,5 +104,20 @@ Examples of `.eslintrc.json`:
       }
     }
   ]
+}
+```
+
+### JavaScript + Jest
+
+```jsonc
+{
+  "extends": ["earlycross/javascript", "earlycross/jest"],
+  "plugins": [
+    // additional plugins
+  ],
+  "env": { "node": true },
+  "rules": {
+    // javascript rules to override
+  }
 }
 ```

--- a/jest.json
+++ b/jest.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["./lib/jest.js"]
+}

--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -1,14 +1,8 @@
 import { Linter } from 'eslint';
 
 const config: Linter.BaseConfig = {
-  extends: [
-    'eslint:recommended',
-    'plugin:import/recommended',
-    'plugin:jsdoc/recommended',
-    'plugin:jest/recommended',
-    'prettier',
-  ],
-  plugins: ['import', 'jsdoc', 'jest'],
+  extends: ['eslint:recommended', 'plugin:import/recommended', 'plugin:jsdoc/recommended', 'prettier'],
+  plugins: ['import', 'jsdoc'],
   parserOptions: { ecmaVersion: 'latest' },
   rules: {
     // Possible Problems
@@ -77,9 +71,6 @@ const config: Linter.BaseConfig = {
     'jsdoc/newline-after-description': ['off'],
     'jsdoc/require-jsdoc': ['off'],
     'jsdoc/require-returns': ['off'],
-
-    // eslint-plugin-jest
-    'jest/expect-expect': ['error', { assertFunctionNames: ['expect**'] }],
   },
 };
 

--- a/src/jest.ts
+++ b/src/jest.ts
@@ -1,0 +1,12 @@
+import { Linter } from 'eslint';
+
+const config: Linter.BaseConfig = {
+  extends: ['plugin:jest/recommended'],
+  plugins: ['jest'],
+  rules: {
+    // eslint-plugin-jest
+    'jest/expect-expect': ['error', { assertFunctionNames: ['expect**'] }],
+  },
+};
+
+export = config;


### PR DESCRIPTION
現状 `eslint-config-earlycross/javascript` に `eslint-plugin-jest` への依存があり、すべてのpresetがこれを引き継ぐ構造になっていますが、これが原因でこのpresetをJestを利用しないプロジェクトで使うのが不便になっています。

このパッケージ内のpresetを使うと強制的に `eslint-plugin-jest` に依存することになりますが、この依存があってかつJestがインストールされていない状態ではeslintがエラーを吐くため、実際にはJestを利用しないにもかかわらずeslintエラーを避けるためにJestをインストールしなければならないという状況に陥っています。

最近はビルドツールとしてViteを採用することが多いのですが、Viteでの開発ではテストにJestではなく[Vitest](https://vitest.dev/)を使うのが基本であり、上記の問題に悩まされてきました。


そこで、Jest用のルールを切り出して独立したpreset(`eslint-config-earlycross/jest`)とし、`eslint-config-earlycross/javascript`から`eslint-plugin-jest`への依存をなくす改修を行いました。

Jestを使うプロジェクトではベースのpresetと一緒に `eslint-config-earlycross/jest` を `extends` する、という使い方を想定しています(READMEに説明を追加してあります)。